### PR TITLE
Replaced getting userID from cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@
  | 0.13 | 3/28/2024 | Lowercase, trim, add dashes to guardian | Luke |
  | 0.14 | 3/28/2024 | normalized DB, fixed php queries, changed error box in login, and register. | Cade |
  | 0.14 | 3/28/2024 | backend for testementary drawer | Cade/liam |
+ | 0.15 | 4/2/2024 | Fixed getting userID with cookies | Luke |

--- a/src/login.php
+++ b/src/login.php
@@ -45,7 +45,7 @@ if (!password_verify($password, $hashedPasswordFromDb)) {
     // Close the statement and connection (already done before)
 
     // Fetch last_login from the database
-    $sql = "SELECT last_login FROM USERS WHERE email = ?";
+    $sql = "SELECT last_login, id FROM USERS WHERE email = ?";
     $params = array($email);
     $stmt = sqlsrv_query($conn, $sql, $params);
 
@@ -55,8 +55,10 @@ if (!password_verify($password, $hashedPasswordFromDb)) {
 
     // Fetch the last_login value and handle potential errors
     $last_login = null;
+    $user_id = null;
     if ($row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_ASSOC)) {
         $last_login = $row['last_login'];
+        $user_id = $row['id'];
     }
 
     if ($last_login) {
@@ -77,6 +79,7 @@ if (!password_verify($password, $hashedPasswordFromDb)) {
         if ($last_login instanceof DateTime) {
             setcookie('last_login', $last_login->format('Y-m-d H:i:s'), time() + 3600, "/");
             setcookie('email', $email, time() + 3600, "/");
+            setcookie('user_id', $user_id, time() + 3600, "/");
 
             echo '<br>' . $last_login->format('Y-m-d H:i:s') . '<br>';
 

--- a/src/logout.php
+++ b/src/logout.php
@@ -1,5 +1,10 @@
 <?php
-// Set the expiration time of the cookies to the past to revoke them
+// Set cookies to blank information to leave no trace.
+setcookie('last_login', '', time() + 3600, "/");
+setcookie('email', '', time() + 3600, "/");
+setcookie('user_id', '', time() + 3600, "/");
+
+// Set the expiration time of the cookies to the past to revoke them.
 setcookie('last_login', '', time() - 3600, "/");
 setcookie('email', '', time() - 3600, "/");
 header("Location: login.html"); 

--- a/src/submit_guardian.php
+++ b/src/submit_guardian.php
@@ -5,10 +5,10 @@ include('config.php'); // Assuming this file contains your database credentials
 // Assuming you have form fields with the names 'fname', 'mname', 'lname', 'relationship'
 $fname = $_POST['fname'];
 $mname = $_POST['mname'];
-if($mname != "") {
-	$mname = $_POST['mname'];
+if ($mname != "") {
+    $mname = $_POST['mname'];
 } else {
-	$mname = ',';
+    $mname = ',';
 }
 $lname = $_POST['lname'];
 $relationship = $_POST['relationship'];
@@ -26,51 +26,38 @@ try {
     $conn->beginTransaction();
 
     // Retrieve email from cookie
-    if (isset($_COOKIE['email'])) {
+    if (isset($_COOKIE['email']) && isset($_COOKIE['user_id'])) {
         $logged_email = $_COOKIE['email'];
-        //echo "Email: " . $logged_email;
+        $user_id = $_COOKIE['user_id'];
 
-        // Check if the user exists
-        $sql_check_user = "SELECT id FROM USERS WHERE email = ?";
-        $stmt_check_user = $conn->prepare($sql_check_user);
-        $stmt_check_user->execute([$logged_email]);
-        $row_check_user = $stmt_check_user->fetch(PDO::FETCH_ASSOC);
+        // Try to UPDATE first, if it fails, INSERT
+        $sql_update_guardian = "UPDATE GUARDIAN SET firstname = ?, middlename = ?, lastname = ?, relationshipToDeceased = ?, has_guardian = '1' WHERE user_id = ?";
+        $params_update_guardian = array($fname, $mname, $lname, $relationship, $user_id);
+        $stmt_update_guardian = $conn->prepare($sql_update_guardian);
+        $success = $stmt_update_guardian->execute($params_update_guardian);
 
-        if ($row_check_user) {
-            $user_id = $row_check_user['id'];
-            //echo "User ID: $user_id";
-
-            // Try to UPDATE first, if it fails, INSERT
-            $sql_update_guardian = "UPDATE GUARDIAN SET firstname = ?, middlename = ?, lastname = ?, relationshipToDeceased = ?, has_guardian = '1' WHERE user_id = ?";
-            $params_update_guardian = array($fname, $mname, $lname, $relationship, $user_id);
-            $stmt_update_guardian = $conn->prepare($sql_update_guardian);
-            $success = $stmt_update_guardian->execute($params_update_guardian);
-
-            if ($success && $stmt_update_guardian->rowCount() > 0) {
-                // Record updated successfully
-                //echo "Guardian information updated successfully.";
-                $conn->commit();
-            } else {
-                // Record not found, try INSERT
-                $sql_insert_guardian = "INSERT INTO GUARDIAN (user_id, firstname, middlename, lastname, relationshipToDeceased, has_guardian) VALUES (?, ?, ?, ?, ?, '1')";
-                $params_insert_guardian = array($user_id, $fname, $mname, $lname, $relationship);
-                $stmt_insert_guardian = $conn->prepare($sql_insert_guardian);
-                $success = $stmt_insert_guardian->execute($params_insert_guardian);
-
-                if ($success) {
-                    //echo "Guardian information inserted successfully.";
-                    // If both queries were successful, commit the transaction
-                    $conn->commit();
-                    //echo "Transaction committed.<br />";
-                } else {
-                    //echo "Error inserting guardian information.";
-                    // Otherwise, rollback the transaction
-                    $conn->rollBack();
-                    //echo "Transaction rolled back.<br />";
-                }
-            }
+        if ($success && $stmt_update_guardian->rowCount() > 0) {
+            // Record updated successfully
+            //echo "Guardian information updated successfully.";
+            $conn->commit();
         } else {
-            //echo "User not found.";
+            // Record not found, try INSERT
+            $sql_insert_guardian = "INSERT INTO GUARDIAN (user_id, firstname, middlename, lastname, relationshipToDeceased, has_guardian) VALUES (?, ?, ?, ?, ?, '1')";
+            $params_insert_guardian = array($user_id, $fname, $mname, $lname, $relationship);
+            $stmt_insert_guardian = $conn->prepare($sql_insert_guardian);
+            $success = $stmt_insert_guardian->execute($params_insert_guardian);
+
+            if ($success) {
+                //echo "Guardian information inserted successfully.";
+                // If both queries were successful, commit the transaction
+                $conn->commit();
+                //echo "Transaction committed.<br />";
+            } else {
+                //echo "Error inserting guardian information.";
+                // Otherwise, rollback the transaction
+                $conn->rollBack();
+                //echo "Transaction rolled back.<br />";
+            }
         }
     } else {
         //echo "Email cookie not set.";


### PR DESCRIPTION
UserID is now a set cookie when logging in and can be accessed using $user_id = $_COOKIE['user_id']; instead of retreiving it from a users email.